### PR TITLE
Fix: Remove docs from ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["node", "react-next", "docs"],
+  "ignore": ["node", "react-next"],
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{commit}"


### PR DESCRIPTION
## Description
The `changeset` github action is failing because the `docs` project no longer exists. This PR remove it from the `ignore` array in the `changeset` config.