### PR TITLE
Fix: wrap createClient in useMemo

### DIFF
--- a/.changeset/nine-frogs-serve.md
+++ b/.changeset/nine-frogs-serve.md
@@ -2,4 +2,10 @@
 "@openformat/react": patch
 ---
 
+### Fixed
+
 - Issue with Wagmi client being recreated multiple times resulting in the signer being null and causing SDK contracts interactions to fail - #139
+
+### Removed
+
+- Temporarily removed WalletConnectConnector from wagmi config until we migrate to a new version of Wagmi - #139

--- a/.changeset/nine-frogs-serve.md
+++ b/.changeset/nine-frogs-serve.md
@@ -1,0 +1,5 @@
+---
+"@openformat/react": patch
+---
+
+- Issue with Wagmi client being recreated multiple times resulting in the signer being null and causing SDK contracts interactions to fail - #139

--- a/packages/react/src/wagmi-client.ts
+++ b/packages/react/src/wagmi-client.ts
@@ -1,30 +1,26 @@
+import { useMemo } from 'react';
 import { Chain, configureChains, createClient } from 'wagmi';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 import { publicProvider } from 'wagmi/providers/public';
 
 export function wagmiClient(acceptedChains: Chain[]) {
-  const { chains, provider, webSocketProvider } = configureChains(
+  const { chains, provider } = configureChains(
     [...acceptedChains],
     [publicProvider()]
   );
 
   const metamask = new MetaMaskConnector({ chains });
 
-  const walletconnect = new WalletConnectConnector({
-    chains,
-    options: {
-      qrcode: true,
-    },
-  });
-
   const injected = new InjectedConnector({ chains });
 
-  return createClient({
-    autoConnect: true,
-    connectors: [injected, metamask, walletconnect],
-    provider,
-    webSocketProvider,
-  });
+  return useMemo(
+    () =>
+      createClient({
+        autoConnect: true,
+        connectors: [injected, metamask],
+        provider,
+      }),
+    []
+  );
 }


### PR DESCRIPTION
<!--
Before going any further:

- Please update the name of the PR to `[TYPE]: [NAME]` e.g `Feature: Registration form`.
- Please add yourself as an assignee.
- Please add the correct label to your PR.


-->

Thank you for contributing to Open Format! Please follow this template to ensure a smooth pull request process. Make sure you have read and followed the guidelines in CONTRIBUTING.md before submitting your pull request.

## Summary

This PR uses `useMemo` too memorise `createClient` from [Wagmi](https://wagmi.sh/).

## Description

We use NextJS for most of our interfaces. We were facing an issue where Wagmi was returning the signer as `null` after refreshing on any page that wasn't the root page. This caused SDK interactions that require a signer to fail. I believe the issue was related to the Wagmi client being recreated multiple times. I memoized the createClient function as suggested in https://github.com/wagmi-dev/wagmi/issues/546#issuecomment-1145200098.

## Type of Change

Please check the boxes that apply to your pull request:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to documentation only)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document
- [x] I have followed the project's [style guide](CONTRIBUTING.md#style-guide)
- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings or errors
- [x] I have made corresponding changes to the documentation
- [x] I have checked that my changes do not introduce any new security vulnerabilities
- [x] I have provided a clear and concise description of my changes
- [x] I have linked to the related issue or bounty, if applicable

## Additional Information

<!-- If you have any additional information or comments related to your pull request, please include them here -->

---

Once again, thank you for your contribution! We appreciate your effort and dedication to improving the Open Format.
